### PR TITLE
feat: make email and birthDate optional in booking form (Closes #1)

### DIFF
--- a/assets/foot-measure-booking.js
+++ b/assets/foot-measure-booking.js
@@ -105,12 +105,12 @@
         isValid = false;
       }
       
-      // Birth date validation
+      // Birth date validation - Optional
       const birthDate = form.querySelector('[name="birthDate"]').value;
-      if (!birthDate) {
-        showError('birthDate', 'Vui lòng chọn ngày sinh', form);
-        isValid = false;
-      }
+      // if (!birthDate) {
+      //   showError('birthDate', 'Vui lòng chọn ngày sinh', form);
+      //   isValid = false;
+      // }
       
       // Phone validation
       const phone = form.querySelector('[name="phone"]').value.trim();
@@ -122,12 +122,9 @@
         isValid = false;
       }
       
-      // Email validation
+      // Email validation - Optional
       const email = form.querySelector('[name="email"]').value.trim();
-      if (!email) {
-        showError('email', 'Vui lòng nhập email', form);
-        isValid = false;
-      } else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      if (email && !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
         showError('email', 'Email không hợp lệ', form);
         isValid = false;
       }

--- a/assets/foot-measure-booking.js
+++ b/assets/foot-measure-booking.js
@@ -105,13 +105,6 @@
         isValid = false;
       }
       
-      // Birth date validation - Optional
-      const birthDate = form.querySelector('[name="birthDate"]').value;
-      // if (!birthDate) {
-      //   showError('birthDate', 'Vui lòng chọn ngày sinh', form);
-      //   isValid = false;
-      // }
-      
       // Phone validation
       const phone = form.querySelector('[name="phone"]').value.trim();
       if (!phone) {

--- a/sections/foot-measure-booking.liquid
+++ b/sections/foot-measure-booking.liquid
@@ -117,14 +117,13 @@
           {%- comment -%} Date of Birth Field {%- endcomment -%}
           <div class="fmb-form__group">
             <label class="fmb-form__label" for="fmb-birthdate-{{ section.id }}">
-              Ngày tháng năm sinh <span class="fmb-form__required">*</span>
+              Ngày tháng năm sinh
             </label>
             <input 
               type="date" 
               class="fmb-form__input" 
               id="fmb-birthdate-{{ section.id }}" 
               name="birthDate"
-              required
             >
             <span class="fmb-form__error" data-field="birthDate"></span>
           </div>
@@ -149,7 +148,7 @@
           {%- comment -%} Email Field {%- endcomment -%}
           <div class="fmb-form__group">
             <label class="fmb-form__label" for="fmb-email-{{ section.id }}">
-              Email <span class="fmb-form__required">*</span>
+              Email
             </label>
             <input 
               type="email" 
@@ -157,7 +156,6 @@
               id="fmb-email-{{ section.id }}" 
               name="email" 
               placeholder="Nhập địa chỉ email"
-              required
             >
             <span class="fmb-form__error" data-field="email"></span>
           </div>


### PR DESCRIPTION
This PR makes the email and date of birth fields optional in the foot measurement booking form. 

Changes:
- Removed 'required' attribute from birthDate and email inputs in liquid.
- Removed required asterisk from labels.
- Updated JS validation to allow empty values for these fields.

Closes #1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make email and date of birth optional in the foot-measure booking form to reduce friction for users. Removed required indicators in `sections/foot-measure-booking.liquid`, updated `assets/foot-measure-booking.js` to drop birth date validation and validate email only if provided, and cleaned up unused `birthDate` code.

<sup>Written for commit df44e83bc32a47d49ccba74c5c58676244b4e483. Summary will update on new commits. <a href="https://cubic.dev/pr/therealtimex/nagen-shopify-theme/pull/2?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

