### PR TITLE
chore: remove Judge.me app blocks from product templates (Closes #3)

### DIFF
--- a/templates/product.grid-view.json
+++ b/templates/product.grid-view.json
@@ -46,10 +46,6 @@
             "custom_liquid": "{%- render 'product-stock', product: product -%}"
           }
         },
-        "judge_me_reviews_preview_badge_AdrweA": {
-          "type": "shopify://apps/judge-me-reviews/blocks/preview_badge/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
-        },
         "title": {
           "type": "title",
           "settings": {
@@ -121,7 +117,6 @@
       "block_order": [
         "vendor",
         "custom_liquid_Cr7Qdw",
-        "judge_me_reviews_preview_badge_AdrweA",
         "title",
         "1393b77e-a8c0-433b-89a8-43bc490e6816",
         "price",
@@ -166,16 +161,11 @@
             "tab_name": "Thông tin bổ sung",
             "tab_custom_content": "<p>By changing our most important processes and <br/>products, we have already made a big leap forward. This ranges from the <br/>increased use of more sustainable fibers to the use of more <br/>environmentally friendly printing processes to the development of <br/>efficient waste management in our value chain.</p><p><br/><a href=\"https://ap-leotheme.myshopify.com/pages/sustainability\" title=\"Sustainability\">Learn more about sustainability</a><br/>                  </p>"
           }
-        },
-        "judge_me_reviews_review_widget_RdR3XX": {
-          "type": "shopify://apps/judge-me-reviews/blocks/review_widget/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
         }
       },
       "block_order": [
         "7cca183b-2a77-4cb3-a100-ae76a5e24b66",
-        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03",
-        "judge_me_reviews_review_widget_RdR3XX"
+        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03"
       ],
       "settings": {
         "enable_guide": true,

--- a/templates/product.left-thumb.json
+++ b/templates/product.left-thumb.json
@@ -46,10 +46,6 @@
             "custom_liquid": "{%- render 'product-stock', product: product -%}"
           }
         },
-        "judge_me_reviews_preview_badge_WJJw4M": {
-          "type": "shopify://apps/judge-me-reviews/blocks/preview_badge/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
-        },
         "title": {
           "type": "title",
           "settings": {
@@ -121,7 +117,6 @@
       "block_order": [
         "vendor",
         "custom_liquid_jEP98f",
-        "judge_me_reviews_preview_badge_WJJw4M",
         "title",
         "1393b77e-a8c0-433b-89a8-43bc490e6816",
         "price",
@@ -166,16 +161,11 @@
             "tab_name": "Thông tin bổ sung",
             "tab_custom_content": "<p>By changing our most important processes and <br/>products, we have already made a big leap forward. This ranges from the <br/>increased use of more sustainable fibers to the use of more <br/>environmentally friendly printing processes to the development of <br/>efficient waste management in our value chain.</p><p><br/><a href=\"https://ap-leotheme.myshopify.com/pages/sustainability\" title=\"Sustainability\">Learn more about sustainability</a><br/>                  </p>"
           }
-        },
-        "judge_me_reviews_review_widget_bKbprb": {
-          "type": "shopify://apps/judge-me-reviews/blocks/review_widget/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
         }
       },
       "block_order": [
         "7cca183b-2a77-4cb3-a100-ae76a5e24b66",
-        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03",
-        "judge_me_reviews_review_widget_bKbprb"
+        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03"
       ],
       "settings": {
         "enable_guide": true,

--- a/templates/product.right-thumb.json
+++ b/templates/product.right-thumb.json
@@ -46,10 +46,6 @@
             "custom_liquid": "{%- render 'product-stock', product: product -%}"
           }
         },
-        "judge_me_reviews_preview_badge_mzDVV8": {
-          "type": "shopify://apps/judge-me-reviews/blocks/preview_badge/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
-        },
         "title": {
           "type": "title",
           "settings": {
@@ -121,7 +117,6 @@
       "block_order": [
         "vendor",
         "custom_liquid_Rx7FwH",
-        "judge_me_reviews_preview_badge_mzDVV8",
         "title",
         "1393b77e-a8c0-433b-89a8-43bc490e6816",
         "price",
@@ -166,16 +161,11 @@
             "tab_name": "Thông tin bổ sung",
             "tab_custom_content": "<p>By changing our most important processes and <br/>products, we have already made a big leap forward. This ranges from the <br/>increased use of more sustainable fibers to the use of more <br/>environmentally friendly printing processes to the development of <br/>efficient waste management in our value chain.</p><p><br/><a href=\"https://ap-leotheme.myshopify.com/pages/sustainability\" title=\"Sustainability\">Learn more about sustainability</a><br/>                  </p>"
           }
-        },
-        "judge_me_reviews_review_widget_GYGbQc": {
-          "type": "shopify://apps/judge-me-reviews/blocks/review_widget/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
         }
       },
       "block_order": [
         "7cca183b-2a77-4cb3-a100-ae76a5e24b66",
-        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03",
-        "judge_me_reviews_review_widget_GYGbQc"
+        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03"
       ],
       "settings": {
         "enable_guide": true,

--- a/templates/product.without-thumbnails.json
+++ b/templates/product.without-thumbnails.json
@@ -46,10 +46,6 @@
             "custom_liquid": "{%- render 'product-stock', product: product -%}"
           }
         },
-        "judge_me_reviews_preview_badge_6rKqDT": {
-          "type": "shopify://apps/judge-me-reviews/blocks/preview_badge/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
-        },
         "title": {
           "type": "title",
           "settings": {
@@ -121,7 +117,6 @@
       "block_order": [
         "vendor",
         "custom_liquid_YkygHw",
-        "judge_me_reviews_preview_badge_6rKqDT",
         "title",
         "1393b77e-a8c0-433b-89a8-43bc490e6816",
         "price",
@@ -166,16 +161,11 @@
             "tab_name": "Thông tin bổ sung",
             "tab_custom_content": "<p>By changing our most important processes and <br/>products, we have already made a big leap forward. This ranges from the <br/>increased use of more sustainable fibers to the use of more <br/>environmentally friendly printing processes to the development of <br/>efficient waste management in our value chain.</p><p><br/><a href=\"https://ap-leotheme.myshopify.com/pages/sustainability\" title=\"Sustainability\">Learn more about sustainability</a><br/>                  </p>"
           }
-        },
-        "judge_me_reviews_review_widget_VGLG7H": {
-          "type": "shopify://apps/judge-me-reviews/blocks/review_widget/61ccd3b1-a9f2-4160-9fe9-4fec8413e5d8",
-          "settings": {}
         }
       },
       "block_order": [
         "7cca183b-2a77-4cb3-a100-ae76a5e24b66",
-        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03",
-        "judge_me_reviews_review_widget_VGLG7H"
+        "5d25217f-c0a7-454c-9bdf-2e9b6e9cfd03"
       ],
       "settings": {
         "enable_guide": true,


### PR DESCRIPTION
This PR syncs the changes made via the Shopify Theme Editor where the Judge.me Product Reviews app blocks were removed from various product templates.

Closes #3

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed `judge-me-reviews` preview badge and review widget blocks from all product templates to satisfy #3 and prevent third-party review widgets from rendering.

Cleaned up `product.grid-view.json`, `product.left-thumb.json`, `product.right-thumb.json`, and `product.without-thumbnails.json` by removing the app blocks and their block_order references.

<sup>Written for commit 0d5d12bce9c9ce533bcca87b6e149005b16ba2e2. Summary will update on new commits. <a href="https://cubic.dev/pr/therealtimex/nagen-shopify-theme/pull/4?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

